### PR TITLE
Fix classes on form groups

### DIFF
--- a/app/views/components/input_checkboxes.scala.html
+++ b/app/views/components/input_checkboxes.scala.html
@@ -26,15 +26,15 @@
         inputs: Seq[RadioOption]
 )(implicit messages: Messages)
 
-<div class="form-field @if(field.hasErrors){form-field--error}">
-    <fieldset class='form-group @fieldsetClass.getOrElse("")' id="@{field.id}">
+<div class="form-group @if(field.hasErrors){form-group-error}">
+    <fieldset class='@fieldsetClass.getOrElse("")' id="@{field.id}">
         <legend>
             <span class="bold-small @if(legendClass.nonEmpty){@{legendClass.get}}">@legend</span>
             @if(hint.nonEmpty){
                 <span class="form-hint">@{hint.get}</span>
             }
             @field.errors.map { error =>
-                <span class="error-notification" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
+                <span class="error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
             }
         </legend>
         @for((input, index) <- inputs.zipWithIndex) {

--- a/app/views/components/input_radio.scala.html
+++ b/app/views/components/input_radio.scala.html
@@ -26,15 +26,15 @@
         inputs: Seq[RadioOption]
 )(implicit messages: Messages)
 
-<div class="form-field @if(field.hasErrors){form-field--error}">
-    <fieldset class='form-group @fieldsetClass.getOrElse("")' id="@{field.id}">
+<div class="form-group @if(field.hasErrors){form-group-error}">
+    <fieldset class='@fieldsetClass.getOrElse("")' id="@{field.id}">
         <legend>
             <span class="bold-small @if(legendClass.nonEmpty){@{legendClass.get}}">@legend</span>
             @if(hint.nonEmpty){
                 <span class="form-hint">@{hint.get}</span>
             }
             @field.errors.map { error =>
-                <span class="error-notification" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
+                <span class="error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
             }
         </legend>
         @for(input <- inputs) {

--- a/app/views/components/input_yes_no.scala.html
+++ b/app/views/components/input_yes_no.scala.html
@@ -26,7 +26,7 @@
 )(implicit messages: Messages)
 
 
-<div class="form-field @if(field.hasErrors){form-field--error}">
+<div class="form-group @if(field.hasErrors){form-group-error}">
     <fieldset class="inline" id="@{field.id}">
 
         <legend>
@@ -35,7 +35,7 @@
                 <span class="form-hint">@hint</span>
             }
             @field.errors.map { error =>
-                <span class="error-notification" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
+                <span class="error-message" id="error-message-@{field.id}-input">@messages(error.message, error.args: _*)</span>
             }
         </legend>
         <div class="multiple-choice">


### PR DESCRIPTION
Changing to use form-group on the outer div, and `error-message` rather than `error-notification`, gives us correctly-styled error messages per GDS.