### PR TITLE
DL-2680: update sbt, play plugin and scalatestplus

### DIFF
--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -22,8 +22,6 @@ import models.requests.OptionalDataRequest
 import play.api.mvc._
 import uk.gov.hmrc.play.HeaderCarrierConverter
 import utils.UserAnswers
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class DataRetrievalActionImpl @Inject()(

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val root = (project in file("."))
   .settings(inConfig(Test)(testSettings): _*)
   .settings(majorVersion := 0)
   .settings(
+    scalaVersion := "2.12.10",
     name := appName,
     RoutesKeys.routesImport += "models._",
     TwirlKeys.templateImports ++= Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,27 +6,28 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "org.reactivemongo" %% "play2-reactivemongo"     % "0.19.0-play26",
-    "uk.gov.hmrc" %% "logback-json-logger"           % "4.6.0",
-    "uk.gov.hmrc" %% "govuk-template"                % "5.48.0-play-26",
-    "uk.gov.hmrc" %% "play-health"                   % "3.14.0-play-26",
-    "uk.gov.hmrc" %% "play-ui"                       % "8.6.0-play-26",
-    "uk.gov.hmrc" %% "http-caching-client"           % "9.0.0-play-26",
-    "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.2.0-play-26",
-    "uk.gov.hmrc" %% "bootstrap-play-26"             % "1.3.0",
-    "uk.gov.hmrc" %% "play-language"                 % "4.1.0",
-    "uk.gov.hmrc" %% "tax-year"                      % "0.6.0"
+    "org.reactivemongo"   %% "play2-reactivemongo"           % "0.20.2-play26",
+    "uk.gov.hmrc"         %% "logback-json-logger"           % "4.6.0",
+    "uk.gov.hmrc"         %% "govuk-template"                % "5.48.0-play-26",
+    "uk.gov.hmrc"         %% "play-health"                   % "3.14.0-play-26",
+    "uk.gov.hmrc"         %% "play-ui"                       % "8.7.0-play-26",
+    "uk.gov.hmrc"         %% "http-caching-client"           % "9.0.0-play-26",
+    "uk.gov.hmrc"         %% "play-conditional-form-mapping" % "1.2.0-play-26",
+    "uk.gov.hmrc"         %% "bootstrap-play-26"             % "1.3.0",
+    "uk.gov.hmrc"         %% "play-language"                 % "4.2.0-play-26",
+    "uk.gov.hmrc"         %% "tax-year"                      % "1.0.0",
+    "com.typesafe.play"   %% "play-iteratees"                % "2.6.1"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-play-26"   % "1.3.0"  classifier "tests",
-    "org.scalatest"           %% "scalatest"           % "3.0.8",
-    "org.scalatestplus.play"  %% "scalatestplus-play"  % "3.1.2",
-    "org.pegdown"             %  "pegdown"             % "1.6.0",
-    "org.jsoup"               %  "jsoup"               % "1.12.1",
-    "com.typesafe.play"       %% "play-test"           % PlayVersion.current,
-    "org.mockito"             %  "mockito-all"         % "1.10.19",
-    "org.scalacheck"          %% "scalacheck"          % "1.14.3"
+    "uk.gov.hmrc"             %% "bootstrap-play-26"     % "1.3.0"  classifier "tests",
+    "org.scalatest"           %% "scalatest"             % "3.0.8",
+    "org.scalatestplus.play"  %% "scalatestplus-play"    % "3.1.3",
+    "org.pegdown"             %  "pegdown"               % "1.6.0",
+    "org.jsoup"               %  "jsoup"                 % "1.12.1",
+    "com.typesafe.play"       %% "play-test"             % PlayVersion.current,
+    "org.mockito"             %  "mockito-all"           % "1.10.19",
+    "org.scalacheck"          %% "scalacheck"            % "1.14.3"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.18
+sbt.version=1.3.7
 hmrc-frontend-scaffold.version=0.6.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test/controllers/actions/DataRequiredActionSpec.scala
+++ b/test/controllers/actions/DataRequiredActionSpec.scala
@@ -17,16 +17,15 @@
 package controllers.actions
 
 import base.SpecBase
-import controllers.routes
 import models.requests.{DataRequest, OptionalDataRequest}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.test.Helpers._
 import play.api.mvc.Result
+import play.api.test.Helpers._
 import utils.UserAnswers
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class DataRequiredActionSpec extends SpecBase with MockitoSugar with ScalaFutures {
 

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -18,12 +18,10 @@ package controllers.actions
 
 import javax.inject.Inject
 import models.requests.OptionalDataRequest
-import play.api.mvc.{AnyContent, BodyParser, MessagesControllerComponents, PlayBodyParsers, Request}
-import play.api.test.Helpers
+import play.api.mvc.{AnyContent, BodyParser, MessagesControllerComponents, Request}
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.UserAnswers
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class FakeDataRetrievalAction @Inject()(cacheMapToReturn: Option[CacheMap], mcc: MessagesControllerComponents) extends DataRetrievalAction {

--- a/test/controllers/actions/GetClaimantActionSpec.scala
+++ b/test/controllers/actions/GetClaimantActionSpec.scala
@@ -17,7 +17,6 @@
 package controllers.actions
 
 import base.SpecBase
-import controllers.routes
 import models.Claimant.You
 import models.requests.DataRequest
 import org.mockito.Mockito._

--- a/test/filters/SessionIdFilterSpec.scala
+++ b/test/filters/SessionIdFilterSpec.scala
@@ -22,7 +22,7 @@ import akka.actor
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import com.google.inject.Inject
-import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import org.scalatest.{OptionValues, WordSpec, MustMatchers}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/forms/ClaimingForFormProviderSpec.scala
+++ b/test/forms/ClaimingForFormProviderSpec.scala
@@ -17,7 +17,6 @@
 package forms
 
 import forms.behaviours.OptionFieldBehaviours
-import models.Claimant.You
 import models.ClaimingFor
 import play.api.data.FormError
 

--- a/test/forms/ClaimingOverPayAsYouEarnThresholdFormProviderSpec.scala
+++ b/test/forms/ClaimingOverPayAsYouEarnThresholdFormProviderSpec.scala
@@ -17,7 +17,6 @@
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
-import models.Claimant.You
 import play.api.data.FormError
 
 class ClaimingOverPayAsYouEarnThresholdFormProviderSpec extends BooleanFieldBehaviours {

--- a/test/forms/EmployerPaidBackExpensesFormProviderSpec.scala
+++ b/test/forms/EmployerPaidBackExpensesFormProviderSpec.scala
@@ -17,7 +17,6 @@
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
-import models.Claimant.You
 import play.api.data.FormError
 
 class EmployerPaidBackExpensesFormProviderSpec extends BooleanFieldBehaviours {

--- a/test/forms/PaidTaxInRelevantYearFormProviderSpec.scala
+++ b/test/forms/PaidTaxInRelevantYearFormProviderSpec.scala
@@ -17,7 +17,6 @@
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
-import models.Claimant.You
 import play.api.data.FormError
 
 class PaidTaxInRelevantYearFormProviderSpec extends BooleanFieldBehaviours {

--- a/test/views/CannotClaimReliefViewSpec.scala
+++ b/test/views/CannotClaimReliefViewSpec.scala
@@ -16,7 +16,6 @@
 
 package views
 
-import models.Claimant.You
 import views.behaviours.ViewBehaviours
 import views.html.CannotClaimReliefView
 

--- a/test/views/ClaimingForViewSpec.scala
+++ b/test/views/ClaimingForViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import forms.ClaimingForFormProvider
-import models.Claimant.You
 import models.{Claimant, ClaimingFor}
+import play.api.data.Form
 import utils.RadioOption
 import views.behaviours.ViewBehaviours
 import views.html.ClaimingForView

--- a/test/views/ClaimingFuelViewSpec.scala
+++ b/test/views/ClaimingFuelViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.ClaimingFuelFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import views.behaviours.YesNoViewBehaviours
 import views.html.ClaimingFuelView
 

--- a/test/views/ClaimingMileageViewSpec.scala
+++ b/test/views/ClaimingMileageViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.ClaimingMileageFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.YesNoViewBehaviours
 import views.html.ClaimingMileageView

--- a/test/views/ClaimingOverPayAsYouEarnThresholdViewSpec.scala
+++ b/test/views/ClaimingOverPayAsYouEarnThresholdViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.ClaimingOverPayAsYouEarnThresholdFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import play.twirl.api.Html
 import views.behaviours.YesNoViewBehaviours
 import views.html.ClaimingOverPayAsYouEarnThresholdView

--- a/test/views/EmployerPaidBackExpensesViewSpec.scala
+++ b/test/views/EmployerPaidBackExpensesViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.EmployerPaidBackExpensesFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import play.twirl.api.Html
 import views.behaviours.YesNoViewBehaviours
 import views.html.EmployerPaidBackExpensesView

--- a/test/views/NotEntitledSomeYearsViewSpec.scala
+++ b/test/views/NotEntitledSomeYearsViewSpec.scala
@@ -17,7 +17,6 @@
 package views
 
 import controllers.routes
-import models.Claimant.You
 import play.twirl.api.HtmlFormat
 import views.behaviours.ViewBehaviours
 import views.html.NotEntitledSomeYearsView

--- a/test/views/NotEntitledViewSpec.scala
+++ b/test/views/NotEntitledViewSpec.scala
@@ -16,7 +16,6 @@
 
 package views
 
-import models.Claimant.You
 import play.twirl.api.HtmlFormat
 import views.behaviours.ViewBehaviours
 import views.html.NotEntitledView

--- a/test/views/PaidTaxInRelevantYearViewSpec.scala
+++ b/test/views/PaidTaxInRelevantYearViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.PaidTaxInRelevantYearFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import play.twirl.api.Html
 import views.behaviours.YesNoViewBehaviours
 import views.html.PaidTaxInRelevantYearView

--- a/test/views/RegisterForSelfAssessmentViewSpec.scala
+++ b/test/views/RegisterForSelfAssessmentViewSpec.scala
@@ -17,10 +17,8 @@
 package views
 
 import controllers.routes
-import models.Claimant.You
 import views.behaviours.ViewBehaviours
 import views.html.RegisterForSelfAssessmentView
-import play.twirl.api.Html
 
 class RegisterForSelfAssessmentViewSpec extends ViewBehaviours {
 

--- a/test/views/RegisteredForSelfAssessmentViewSpec.scala
+++ b/test/views/RegisteredForSelfAssessmentViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.RegisteredForSelfAssessmentFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import play.twirl.api.Html
 import views.behaviours.YesNoViewBehaviours
 import views.html.RegisteredForSelfAssessmentView

--- a/test/views/UseOwnCarViewSpec.scala
+++ b/test/views/UseOwnCarViewSpec.scala
@@ -16,10 +16,9 @@
 
 package views
 
-import play.api.data.Form
 import controllers.routes
 import forms.UseOwnCarFormProvider
-import models.Claimant.You
+import play.api.data.Form
 import views.behaviours.YesNoViewBehaviours
 import views.html.UseOwnCarView
 


### PR DESCRIPTION
# DL-2680 - descriptive title

**Maintenance**

Updated scalatestplus, play plugin, play2-reactivemongo, play-language, scala version and sbt version. Could not update scalatest as it causes conflicts with scalatestplus.

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
