### PR TITLE
DL-2680: Switched to use simple-reactivemongo, overidden dependency t…

### DIFF
--- a/app/connectors/DataCacheConnector.scala
+++ b/app/connectors/DataCacheConnector.scala
@@ -19,33 +19,33 @@ package connectors
 import identifiers.Identifier
 import javax.inject.Inject
 import play.api.libs.json.{Format, Json}
-import repositories.ReactiveMongoRepository
+import repositories.SessionRepository
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.CascadeUpsert
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class DataCacheConnectorImpl @Inject()(val sessionRepository: ReactiveMongoRepository, val cascadeUpsert: CascadeUpsert) extends DataCacheConnector {
+class DataCacheConnectorImpl @Inject()(val sessionRepository: SessionRepository, val cascadeUpsert: CascadeUpsert) extends DataCacheConnector {
 
   def save[A](cacheId: String, key: Identifier, value: A)(implicit fmt: Format[A]): Future[CacheMap] = {
-    sessionRepository.get(cacheId).flatMap { optionalCacheMap =>
+    sessionRepository().get(cacheId).flatMap { optionalCacheMap =>
       val updatedCacheMap = cascadeUpsert(key, value, optionalCacheMap.getOrElse(new CacheMap(cacheId, Map())))
-      sessionRepository.upsert(updatedCacheMap).map {_ => updatedCacheMap}
+      sessionRepository().upsert(updatedCacheMap).map {_ => updatedCacheMap}
     }
   }
 
   def remove(cacheId: String, key: Identifier): Future[Boolean] = {
-    sessionRepository.get(cacheId).flatMap { optionalCacheMap =>
+    sessionRepository().get(cacheId).flatMap { optionalCacheMap =>
       optionalCacheMap.fold(Future(false)) { cacheMap =>
         val newCacheMap = cacheMap copy (data = cacheMap.data - key.toString)
-        sessionRepository.upsert(newCacheMap)
+        sessionRepository().upsert(newCacheMap)
       }
     }
   }
 
   def fetch(cacheId: String): Future[Option[CacheMap]] =
-    sessionRepository.get(cacheId)
+    sessionRepository().get(cacheId)
 
   def getEntry[A](cacheId: String, key: Identifier)(implicit fmt: Format[A]): Future[Option[A]] = {
     fetch(cacheId).map { optionalCacheMap =>
@@ -54,14 +54,14 @@ class DataCacheConnectorImpl @Inject()(val sessionRepository: ReactiveMongoRepos
   }
 
   def addToCollection[A](cacheId: String, collectionKey: Identifier, value: A)(implicit fmt: Format[A]): Future[CacheMap] = {
-    sessionRepository.get(cacheId).flatMap { optionalCacheMap =>
+    sessionRepository().get(cacheId).flatMap { optionalCacheMap =>
       val updatedCacheMap = cascadeUpsert.addRepeatedValue(collectionKey, value, optionalCacheMap.getOrElse(new CacheMap(cacheId, Map())))
-      sessionRepository.upsert(updatedCacheMap).map {_ => updatedCacheMap}
+      sessionRepository().upsert(updatedCacheMap).map {_ => updatedCacheMap}
     }
   }
 
   def removeFromCollection[A](cacheId: String, collectionKey: Identifier, item: A)(implicit fmt: Format[A]): Future[CacheMap] = {
-    sessionRepository.get(cacheId).flatMap { optionalCacheMap =>
+    sessionRepository().get(cacheId).flatMap { optionalCacheMap =>
       optionalCacheMap.fold(throw new Exception(s"Couldn't find document with key $cacheId")) {cacheMap =>
         val newSeq = cacheMap.data(collectionKey.toString).as[Seq[A]].filterNot(x => x == item)
         val newCacheMap = if (newSeq.isEmpty) {
@@ -70,17 +70,17 @@ class DataCacheConnectorImpl @Inject()(val sessionRepository: ReactiveMongoRepos
           cacheMap copy (data = cacheMap.data + (collectionKey.toString -> Json.toJson(newSeq)))
         }
 
-        sessionRepository.upsert(newCacheMap).map {_ => newCacheMap}
+        sessionRepository().upsert(newCacheMap).map {_ => newCacheMap}
       }
     }
   }
 
   def replaceInCollection[A](cacheId: String, collectionKey: Identifier, index: Int, item: A)(implicit fmt: Format[A]): Future[CacheMap] = {
-    sessionRepository.get(cacheId).flatMap { optionalCacheMap =>
+    sessionRepository().get(cacheId).flatMap { optionalCacheMap =>
       optionalCacheMap.fold(throw new Exception(s"Couldn't find document with key $cacheId")) {cacheMap =>
         val newSeq = cacheMap.data(collectionKey.toString).as[Seq[A]].updated(index, item)
         val updatedCacheMap = cacheMap copy (data = cacheMap.data + (collectionKey.toString -> Json.toJson(newSeq)))
-        sessionRepository.upsert(updatedCacheMap).map {_ => updatedCacheMap}
+        sessionRepository().upsert(updatedCacheMap).map {_ => updatedCacheMap}
       }
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val root = (project in file("."))
     ScoverageKeys.coverageHighlighting := true,
     scalacOptions ++= Seq("-feature"),
     libraryDependencies ++= AppDependencies(),
+    dependencyOverrides += "commons-codec" % "commons-codec" % "1.12",
     retrieveManaged := true,
     evictionWarningOptions in update :=
       EvictionWarningOptions.default.withWarnScalaVersionEviction(false),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,7 +65,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoModule"
 play.modules.enabled += "config.Module"
 
 play.i18n.langs = ["en"]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "org.reactivemongo"   %% "play2-reactivemongo"           % "0.20.2-play26",
+    "uk.gov.hmrc"         %% "simple-reactivemongo"          % "7.23.0-play-26",
     "uk.gov.hmrc"         %% "logback-json-logger"           % "4.6.0",
     "uk.gov.hmrc"         %% "govuk-template"                % "5.48.0-play-26",
     "uk.gov.hmrc"         %% "play-health"                   % "3.14.0-play-26",

--- a/project/scaffold.sbt
+++ b/project/scaffold.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")
+addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.12.0")


### PR DESCRIPTION
…o fix qa deployment issue

# DL-2680

**Bug fix**

Changed to using hmrc's simple-reactivemongo library, overridden the commons-codec dependency as this causes issues with deploying to qa.

## Checklist

*Reviewee* (Replace with your name)
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

*Reviewer* (Replace with your name)
 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
