### PR TITLE
DL-9267 - WhichYearsAreYouClaimingForView

### DIFF
--- a/app/controllers/WhichYearsAreYouClaimingForController.scala
+++ b/app/controllers/WhichYearsAreYouClaimingForController.scala
@@ -59,10 +59,11 @@ class WhichYearsAreYouClaimingForController @Inject()(
     implicit request =>
 
       val form: Form[Int] = formProvider(request.claimant)
+      val saUser: Boolean = request.userAnswers.registeredForSelfAssessment.getOrElse(false)
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, request.claimant))),
+          Future.successful(BadRequest(view(formWithErrors, request.claimant, saUser))),
         value =>
           dataCacheConnector.save[Int](request.sessionId, WhichYearsAreYouClaimingForId, value).map(cacheMap =>
             Redirect(navigator.nextPage(WhichYearsAreYouClaimingForId)(new UserAnswers(cacheMap)))

--- a/app/views/WhichYearsAreYouClaimingForView.scala.html
+++ b/app/views/WhichYearsAreYouClaimingForView.scala.html
@@ -14,30 +14,14 @@
  * limitations under the License.
  *@
 
-@import config.FrontendAppConfig
 @import controllers.routes._
-@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukBackLink, GovukButton, GovukInsetText, GovukRadios}
-@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.button.Button
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.{RadioItem, Radios}
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.ErrorSummary
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.ErrorLink
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, HtmlContent, Empty}
 
 @this(
     layout: Layout,
-    govukBackLink : GovukBackLink,
-    govukRadios : GovukRadios,
-    govukInsetText : GovukInsetText,
-    govukButton : GovukButton,
-    govukErrorSummary : GovukErrorSummary,
     formHelper: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
-    appConfig: FrontendAppConfig
+    inputRadio: playComponents.input_radio,
+    submitButton: playComponents.submit_button,
+    errorSummary: playComponents.error_summary
 )
 
 @(form: Form[_], claimant: Claimant, isSaUser: Boolean = false)(implicit request: Request[_], messages: Messages)
@@ -55,48 +39,15 @@
     <p class="govuk-body">@messages(s"whichYearsAreYouClaimingFor.$claimant.both.tax.years.info.text.2")</p>
 }
 
-@htmlHint = {
-    <p class="govuk-body">@messages(s"whichYearsAreYouClaimingFor.$claimant.main.info.text")</p>
-}
-
 @layout(
     pageTitle = s"${errorPrefix(form)} ${messages(s"whichYearsAreYouClaimingFor.$claimant.title")}"
 ) {
-    <p>
-        @govukBackLink(BackLink(
-            href = "javascript:history.back()",
-            content = Text(messages("site.back")),
-            attributes = Map("id" -> "back-link")
-        ))
-    </p>
+    @errorSummary(form.errors)
     @formHelper(action = WhichYearsAreYouClaimingForController.onSubmit(), 'autoComplete -> "off") {
-
-        @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummary(
-                title       = Text(messages("error.summary.title")),
-                errorList   = for(error <- form.errors) yield {
-                    ErrorLink(
-                        href    = Some(s"#${error.key}"),
-                        content = Text(messages(error.message, error.args:_*))
-                    )
-                }
-            ))
-        }
-
-        @govukRadios(Radios(
-            fieldset = Some(Fieldset(
-                legend = Some(Legend(
-                    content = Text(messages(s"whichYearsAreYouClaimingFor.$claimant.heading")),
-                    classes = "govuk-fieldset__legend--l",
-                    isPageHeading = true
-                )),
-
-            )),hint = if(isSaUser) { Some(
-                    Hint(
-                        content = HtmlContent(htmlHint)
-                        )
-                    )
-                } else None,
+        @inputRadio(
+            field = form("value"),
+            legend = messages(s"whichYearsAreYouClaimingFor.$claimant.heading"),
+            hint = if(isSaUser) Some(messages(s"whichYearsAreYouClaimingFor.$claimant.main.info.text")) else None,
             items = Seq(
                 RadioItem(
                     content = Text(messages("whichYearsAreYouClaimingFor.current.tax.year.text")),
@@ -114,11 +65,8 @@
                     conditionalHtml = if(isSaUser) {Some(bothTaxYearHtml)} else None
                 )
             )
-        ).withFormField(form("value")))
-
-        @govukButton(Button(
-            content = Text(messages("site.save_and_continue"))
-        ))
+        )
+        @submitButton()
     }
 }
 

--- a/test/views/WhichYearsAreYouClaimingForViewSpec.scala
+++ b/test/views/WhichYearsAreYouClaimingForViewSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import controllers.routes
+import forms.WhichYearsAreYouClaimingForFormProvider
+import play.api.data.Form
+import views.behaviours.RadioOptionViewBehaviours
+import views.html.WhichYearsAreYouClaimingForView
+
+class WhichYearsAreYouClaimingForViewSpec extends RadioOptionViewBehaviours {
+
+  val messageKeyPrefix = s"whichYearsAreYouClaimingFor.$claimant"
+
+  val application = applicationBuilder().build
+
+  val view = application.injector.instanceOf[WhichYearsAreYouClaimingForView]
+
+  val form: Form[Int] = new WhichYearsAreYouClaimingForFormProvider()(claimant)
+
+  def createView(isSaUser: Boolean, form: Form[_]) = view.apply(form, claimant, isSaUser)(fakeRequest, messages)
+
+  val numberOfOptions: Int = 3
+
+  "WhichYearsAreYouClaimingFor view" when {
+
+    "the user won't complete their Self-Assessment return for this tax year" must {
+      behave like normalPage(createView(false, form), messageKeyPrefix)
+      behave like radioOptionPage(createView(false, _), messageKeyPrefix)
+      behave like pageWithBackLink(createView(false, form))
+    }
+
+    "the user will complete their Self-Assessment return for this tax year" must {
+      behave like normalPage(createView(true, form), messageKeyPrefix)
+      behave like radioOptionPage(createView(true, _), messageKeyPrefix)
+      behave like pageWithBackLink(createView(true, form))
+
+      "show SA-specific hint text" in {
+        val doc = asDocument(createView(true, form))
+        assertContainsMessages(doc, s"whichYearsAreYouClaimingFor.$claimant.current.tax.year.info.text")
+        assertContainsMessages(doc, s"whichYearsAreYouClaimingFor.$claimant.previous.tax.year.info.text")
+        assertContainsMessages(doc, s"whichYearsAreYouClaimingFor.$claimant.both.tax.years.info.text.1")
+        assertContainsMessages(doc, s"whichYearsAreYouClaimingFor.$claimant.both.tax.years.info.text.2")
+      }
+    }
+  }
+
+  application.stop
+}

--- a/test/views/behaviours/RadioOptionViewBehaviours.scala
+++ b/test/views/behaviours/RadioOptionViewBehaviours.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.behaviours
+
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+
+trait RadioOptionViewBehaviours extends NewQuestionViewBehaviours[Int] {
+  val numberOfOptions: Int
+
+  def radioOptionPage(createView: (Form[Int]) => HtmlFormat.Appendable,
+                messageKeyPrefix: String,
+                headingArgs: Any*) = {
+
+    "behave like a page with a radio options question" when {
+      "rendered" must {
+        "contain a legend for the question" in {
+          val doc = asDocument(createView(form))
+          val legends = doc.getElementsByTag("legend")
+          legends.size mustBe 1
+          legends.first.text contains messages(s"$messageKeyPrefix.heading", headingArgs:_*)
+        }
+
+        "contain an input for the value" in {
+          val doc = asDocument(createView(form))
+          for(i <- 1 to numberOfOptions) {
+            assertRenderedById(doc, answerId(i))
+          }
+        }
+
+        "have no values checked when rendered with no form" in {
+          val doc = asDocument(createView(form))
+          for(i <- 1 to numberOfOptions) {
+            assert(!doc.getElementById(answerId(i)).hasAttr("checked"))
+          }
+        }
+
+        "not render an error summary" in {
+          val doc = asDocument(createView(form))
+          assertNotRenderedById(doc, "error-summary_header")
+        }
+      }
+
+      "render with a value" must {
+        behave like answeredRadioOptionPage(createView)
+      }
+
+      "render with an error" must {
+        "show an error summary" in {
+          val doc = asDocument(createView(form.withError(error)))
+          assertRenderedByCssSelector(doc, ".govuk-error-summary")
+        }
+
+        "show an error in the value field's label" in {
+          val doc = asDocument(createView(form.withError(error)))
+          val errorSpan = doc.getElementById("value-error")
+          errorSpan.text mustBe s"Error: ${messages(errorMessage)}"
+        }
+      }
+    }
+  }
+
+
+  def answeredRadioOptionPage(createView: Form[Int] => HtmlFormat.Appendable) = {
+    for(answer <- 1 to numberOfOptions){
+      s"have only the correct value ($answer) checked" in {
+        val doc = asDocument(createView(form.fill(answer)))
+        assert(doc.getElementById(answerId(answer)).hasAttr("checked"))
+        for(notAnswer <- 1 to numberOfOptions){
+          if(notAnswer != answer){
+            assert(!doc.getElementById(answerId(notAnswer)).hasAttr("checked"))
+          }
+        }
+      }
+      s"not render an error summary for value ($answer)" in {
+        val doc = asDocument(createView(form.fill(answer)))
+        assertNotRenderedById(doc, "error-summary_header")
+      }
+    }
+  }
+
+  private def answerId(answer: Int): String = {
+    s"value${if(answer != 1) s"-$answer" else ""}"
+  }
+}


### PR DESCRIPTION
# DL-9267 - WhichYearsAreYouClaimingForView

Changed the `onSubmit` action to respect whether the user is completing their SA return after a form error occurs.

## Checklist

*Reviewee* (Replace with your name)
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
