### PR TITLE
DL-9543 - Made service URLs relative

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,14 +110,14 @@ urls {
   taxReliefForEmployees = "https://www.gov.uk/tax-relief-for-employees"
   taxReliefForEmployeesWFHUrl = "https://www.gov.uk/tax-relief-for-employees/working-at-home"
   buisnessMileageFuelCostsUrl = "https://www.gov.uk/tax-relief-for-employees/business-mileage-fuel-costs"
-  employeeExpensesUrl = "https://www.tax.service.gov.uk/employee-expenses"
-  professionalSubscriptionsUrl = "https://www.tax.service.gov.uk/professional-subscriptions"
+  employeeExpensesUrl = "http://localhost:9334/employee-expenses"
+  professionalSubscriptionsUrl = "http://localhost:9335/professional-subscriptions"
   employeeExpensesClaimOnlineUrl = "https://www.gov.uk/guidance/claim-income-tax-relief-for-your-employment-expenses-p87#claim-online"
   employeeExpensesClaimByPostUrl = "https://www.gov.uk/guidance/claim-income-tax-relief-for-your-employment-expenses-p87#claim-by-post"
   whoMustSendATaxReturnUrl = "https://www.gov.uk/self-assessment-tax-returns/who-must-send-a-tax-return"
   fileSelfAssessmentLoginUrl = "https://www.gov.uk/log-in-file-self-assessment-tax-return"
   annualInvestmentAllowanceUrl = "https://www.gov.uk/capital-allowances/annual-investment-allowance"
-  workingFromHomeExpensesUrl = "https://www.tax.service.gov.uk/employee-working-from-home-expenses"
+  workingFromHomeExpensesUrl = "http://localhost:9336/employee-working-from-home-expenses"
   jobExpensesGuidanceUrl = "https://www.gov.uk/guidance/job-expenses-for-uniforms-work-clothing-and-tools#if-your-employer-pays-towards-the-costs-of-your-expenses"
 }
 

--- a/test/views/ClaimOnlineViewSpec.scala
+++ b/test/views/ClaimOnlineViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views
 
+import config.FrontendAppConfig
 import org.jsoup.nodes.Element
 import play.twirl.api.Html
 import viewmodels.OnwardJourney
@@ -45,7 +46,7 @@ class ClaimOnlineViewSpec extends NewViewBehaviours {
       val view = application.injector.instanceOf[ClaimOnlineView]
       val doc = asDocument(view(OnwardJourney.FixedRateExpenses, None)(fakeRequest, messages))
       val button: Element = doc.getElementById("continue")
-      button.attr("href") must be("https://www.tax.service.gov.uk/employee-expenses")
+      button.attr("href") must be(frontendAppConfig.employeeExpensesUrl)
       assertPageTitleEqualsMessage(doc, "claimOnline.heading")
     }
 
@@ -53,7 +54,7 @@ class ClaimOnlineViewSpec extends NewViewBehaviours {
       val view = application.injector.instanceOf[ClaimOnlineView]
       val doc = asDocument(view(OnwardJourney.ProfessionalSubscriptions, None)(fakeRequest, messages))
       val button: Element = doc.getElementById("continue")
-      button.attr("href") must be("https://www.tax.service.gov.uk/professional-subscriptions")
+      button.attr("href") must be(frontendAppConfig.professionalSubscriptionsUrl)
       assertPageTitleEqualsMessage(doc, "claimOnline.heading")
     }
 
@@ -61,7 +62,7 @@ class ClaimOnlineViewSpec extends NewViewBehaviours {
       val view = application.injector.instanceOf[ClaimOnlineView]
       val doc = asDocument(view(OnwardJourney.WorkingFromHomeExpensesOnly, Some("link-with-session-id"), isSaUser = false)(fakeRequest, messages))
       val button: Element = doc.getElementById("continue")
-      button.attr("href") must be("https://www.tax.service.gov.uk/employee-working-from-home-expenses")
+      button.attr("href") must be(frontendAppConfig.workingFromHomeExpensesUrl)
       assertPageTitleEqualsMessage(doc, "claimOnline.wfh.heading")
     }
 
@@ -69,7 +70,7 @@ class ClaimOnlineViewSpec extends NewViewBehaviours {
       val view = application.injector.instanceOf[ClaimOnlineView]
       val doc = asDocument(view(OnwardJourney.WorkingFromHomeExpensesOnly, Some("link-with-session-id"), isSaUser = true)(fakeRequest, messages))
       val button: Element = doc.getElementById("continue")
-      button.attr("href") must be("https://www.tax.service.gov.uk/employee-working-from-home-expenses?eligibilityCheckerSessionId=link-with-session-id")
+      button.attr("href") must be(s"${frontendAppConfig.workingFromHomeExpensesUrl}?eligibilityCheckerSessionId=link-with-session-id")
       assertPageTitleEqualsMessage(doc, "claimOnline.wfh.heading")
     }
 


### PR DESCRIPTION
# DL-9543 - Made service URLs relative

Made config for the links for employee-expenses, professional-subscriptions and EE-WFH relative to environment

app-config-base: https://github.com/hmrc/app-config-base/pull/8065

## Checklist

*Stephen*
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
