### PR TITLE
DL-9595 - Claim by weeks for SA-claimants

### DIFF
--- a/app/controllers/DisclaimerController.scala
+++ b/app/controllers/DisclaimerController.scala
@@ -34,12 +34,7 @@ class DisclaimerController  @Inject()(
 
   def onPageLoad: Action[AnyContent] = (getData andThen requireData andThen getClaimant) {
     implicit request =>
-      val whichYears = request.userAnswers.whichYearsAreYouClaimingFor.getOrElse(3)
-
-      val claimingForCurrent: Boolean = whichYears == 1 || whichYears == 3
-      val claimingForPrev: Boolean = whichYears == 2 || whichYears == 3
-
-      Ok(view(request.claimant, claimingForCurrent, claimingForPrev))
+      Ok(view(request.claimant))
   }
 
 }

--- a/app/controllers/InformCustomerClaimNowInWeeksController.scala
+++ b/app/controllers/InformCustomerClaimNowInWeeksController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, GetClaimantAction}
+import identifiers.InformCustomerClaimNowInWeeksId
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -38,6 +39,11 @@ class InformCustomerClaimNowInWeeksController @Inject()(
   def onPageLoad: Action[AnyContent] = (getData andThen requireData andThen getClaimant) {
     implicit request =>
       Ok(informClaimNowInWeeksView())
+  }
+
+  def onSubmit: Action[AnyContent] = (getData andThen requireData andThen getClaimant) {
+    implicit request =>
+      Redirect(navigator.nextPage(InformCustomerClaimNowInWeeksId)(request.userAnswers))
   }
 
 }

--- a/app/identifiers/EmployerPaidBackWfhExpensesId.scala
+++ b/app/identifiers/EmployerPaidBackWfhExpensesId.scala
@@ -17,5 +17,5 @@
 package identifiers
 
 case object EmployerPaidBackWfhExpensesId extends Identifier {
-  override def toString: String = "employerPaid"
+  override def toString: String = "employerPaidWfh"
 }

--- a/app/utils/Navigator.scala
+++ b/app/utils/Navigator.scala
@@ -157,10 +157,24 @@ class Navigator @Inject()() {
 
   private def whichYearsAreYouClaimingForRouting(userAnswers: UserAnswers) = userAnswers.whichYearsAreYouClaimingFor match {
     case Some(1) =>
+        routes.InformCustomerClaimNowInWeeksController.onPageLoad()
+    case Some(2) =>
+      if(userAnswers.registeredForSelfAssessment.getOrElse(false)) {
+        routes.UseSelfAssessmentController.onPageLoad()
+      } else {
+        routes.EmployerPaidBackWfhExpensesController.onPageLoad()
+      }
+    case Some(3) =>
+        routes.InformCustomerClaimNowInWeeksController.onPageLoad()
+    case _ => routes.SessionExpiredController.onPageLoad
+  }
+
+  private def informCustomerClaimNowInWeeksRouting(userAnswers: UserAnswers) = userAnswers.whichYearsAreYouClaimingFor match {
+    case Some(1) =>
       if(userAnswers.registeredForSelfAssessment.getOrElse(false)) {
         routes.SaCheckDisclaimerCurrentYearController.onPageLoad()
       } else {
-        routes.InformCustomerClaimNowInWeeksController.onPageLoad()
+        routes.EmployerPaidBackWfhExpensesController.onPageLoad()
       }
     case Some(2) =>
       if(userAnswers.registeredForSelfAssessment.getOrElse(false)) {
@@ -172,10 +186,11 @@ class Navigator @Inject()() {
       if(userAnswers.registeredForSelfAssessment.getOrElse(false)) {
         routes.SaCheckDisclaimerAllYearsController.onPageLoad()
       } else {
-        routes.InformCustomerClaimNowInWeeksController.onPageLoad()
+        routes.EmployerPaidBackWfhExpensesController.onPageLoad()
       }
     case _ => routes.SessionExpiredController.onPageLoad
   }
+
 
   private def changeOtherExpensesRouting(userAnswers: UserAnswers) = userAnswers.claimant match {
     case Some(You) => routes.MoreThanFiveJobsController.onPageLoad()
@@ -219,6 +234,7 @@ class Navigator @Inject()() {
     ClaimingFuelId -> claimingFuelRouting,
     WillPayTaxId -> willPayTaxRouting,
     WhichYearsAreYouClaimingForId -> whichYearsAreYouClaimingForRouting,
+    InformCustomerClaimNowInWeeksId -> informCustomerClaimNowInWeeksRouting,
     WillNotPayTaxId -> (_ => routes.RegisteredForSelfAssessmentController.onPageLoad()),
     RegisterForSelfAssessmentId -> (_ => routes.EmployerPaidBackExpensesController.onPageLoad()),
     ChangeOtherExpensesId -> changeOtherExpensesRouting,

--- a/app/utils/UserAnswers.scala
+++ b/app/utils/UserAnswers.scala
@@ -37,7 +37,7 @@ class UserAnswers(val cacheMap: CacheMap) extends Enumerable.Implicits {
 
   def employerPaidBackExpenses: Option[Boolean] = cacheMap.getEntry[Boolean](EmployerPaidBackExpensesId.toString)
 
-  def employerPaidBackWFHExpenses: Option[EmployerPaid] = cacheMap.getEntry[EmployerPaid](EmployerPaidBackExpensesId.toString)
+  def employerPaidBackWFHExpenses: Option[EmployerPaid] = cacheMap.getEntry[EmployerPaid](EmployerPaidBackWfhExpensesId.toString)
 
   def moreThanFiveJobs: Option[Boolean] = cacheMap.getEntry[Boolean](MoreThanFiveJobsId.toString)
 

--- a/app/views/DisclaimerView.scala.html
+++ b/app/views/DisclaimerView.scala.html
@@ -21,7 +21,7 @@
         submitButton: playComponents.submit_button
 )
 
-@(claimant: Claimant, claimingCurrent: Boolean, claimingPrevious: Boolean)(implicit request: Request[_], messages: Messages)
+@(claimant: Claimant)(implicit request: Request[_], messages: Messages)
 
 @notificationBannerHtml = {
     <p class="govuk-notification-banner__heading">
@@ -35,40 +35,34 @@
 
     @heading(messages("disclaimer.heading"))
 
-    @if(claimingCurrent) {
-        @govukNotificationBanner(NotificationBanner(
-            title = HtmlContent(messages("disclaimer.guidance.header")),
-            content = HtmlContent(notificationBannerHtml)
-        ))
-    }
+    @govukNotificationBanner(NotificationBanner(
+        title = HtmlContent(messages("disclaimer.guidance.header")),
+        content = HtmlContent(notificationBannerHtml)
+    ))
 
-    @if(claimingCurrent) {
-        <h2 class="govuk-heading-m">@messages("disclaimer.claim.after.h2")</h2>
-        <p class="govuk-body">@messages("disclaimer.claim.after.p1")</p>
-        <p class="govuk-body">@messages("disclaimer.claim.p1")</p>
-        <p class="govuk-body">@messages("disclaimer.claim.after.p2")</p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>@messages("disclaimer.claim.after.l1")</li>
-            <li>@messages("disclaimer.claim.after.l2")</li>
-            <li>@messages("disclaimer.claim.after.l3")</li>
-        </ul>
-    }
+    <h2 class="govuk-heading-m">@messages("disclaimer.claim.after.h2")</h2>
+    <p class="govuk-body">@messages("disclaimer.claim.after.p1")</p>
+    <p class="govuk-body">@messages("disclaimer.claim.p1")</p>
+    <p class="govuk-body">@messages("disclaimer.claim.after.p2")</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>@messages("disclaimer.claim.after.l1")</li>
+        <li>@messages("disclaimer.claim.after.l2")</li>
+        <li>@messages("disclaimer.claim.after.l3")</li>
+    </ul>
 
-    @if(claimingPrevious) {
-        <h2 class="govuk-heading-m">@messages("disclaimer.claim.before.h2")</h2>
-        <p class="govuk-body">@messages("disclaimer.claim.before.p1")</p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>@messages("disclaimer.claim.before.l1")</li>
-            <li>@messages("disclaimer.claim.before.l2")</li>
-            <li>@messages("disclaimer.claim.before.l3")</li>
-        </ul>
-    }
+    <h2 class="govuk-heading-m">@messages("disclaimer.claim.before.h2")</h2>
+    <p class="govuk-body">@messages("disclaimer.claim.before.p1")</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>@messages("disclaimer.claim.before.l1")</li>
+        <li>@messages("disclaimer.claim.before.l2")</li>
+        <li>@messages("disclaimer.claim.before.l3")</li>
+    </ul>
 
     <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>
-            @if(claimingCurrent) {@messages("disclaimer.warning1")<br>}
+            @messages("disclaimer.warning1")<br>
             @messages("disclaimer.warning2")<br>
         </strong>
     </div>

--- a/app/views/InformCustomerClaimNowInWeeksView.scala.html
+++ b/app/views/InformCustomerClaimNowInWeeksView.scala.html
@@ -37,7 +37,7 @@ pageTitle = messages(s"informCustomerClaimNowInWeeks.heading")
 
     <p class="govuk-body">@messages("informCustomerClaimNowInWeeks.para3")</p>
 
-    @formHelper(action = EmployerPaidBackWfhExpensesController.onPageLoad(), 'autoComplete -> "off") {
+    @formHelper(action = InformCustomerClaimNowInWeeksController.onSubmit(), 'autoComplete -> "off") {
         @button(Button(content = Text(messages("site.save_and_continue")), preventDoubleClick  = true))
     }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -20,6 +20,7 @@ GET        /which-years-are-you-claiming-for            controllers.WhichYearsAr
 POST       /which-years-are-you-claiming-for            controllers.WhichYearsAreYouClaimingForController.onSubmit()
 
 GET        /inform-customer-claim-now-in-weeks          controllers.InformCustomerClaimNowInWeeksController.onPageLoad()
+POST       /inform-customer-claim-now-in-weeks          controllers.InformCustomerClaimNowInWeeksController.onSubmit()
 
 GET        /sa-check-disclaimer-current-year            controllers.SaCheckDisclaimerCurrentYearController.onPageLoad()
 GET        /sa-check-disclaimer-all-years               controllers.SaCheckDisclaimerAllYearsController.onPageLoad()

--- a/test/controllers/DisclaimerControllerSpec.scala
+++ b/test/controllers/DisclaimerControllerSpec.scala
@@ -39,7 +39,7 @@ class DisclaimerControllerSpec extends SpecBase {
       val view = application.injector.instanceOf[DisclaimerView]
 
       status(result) mustBe OK
-      contentAsString(result) mustBe view(claimant, true, true)(request, messages).toString
+      contentAsString(result) mustBe view(claimant)(request, messages).toString
 
       application.stop
     }

--- a/test/utils/NavigatorSpec.scala
+++ b/test/utils/NavigatorSpec.scala
@@ -138,7 +138,7 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
 
     }
 
-    "go to the SaCheckDisclaimerCurrentYearView view" when {
+    "go to the InformCustomerClaimNowInWeeks view" when {
       "answering 'Just the current tax year 2021-2022'" in {
         val mockAnswers = mock[UserAnswers]
         when(mockAnswers.claimAnyOtherExpense).thenReturn(None)
@@ -146,7 +146,7 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
         when(mockAnswers.whichYearsAreYouClaimingFor).thenReturn(Some(1))
 
         navigator.nextPage(WhichYearsAreYouClaimingForId)(mockAnswers) mustBe
-          routes.SaCheckDisclaimerCurrentYearController.onPageLoad()
+          routes.InformCustomerClaimNowInWeeksController.onPageLoad()
       }
     }
 
@@ -162,7 +162,7 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
       }
     }
 
-    "go to the SaCheckDisclaimerAllYearsView view" when {
+    "go to the InformCustomerClaimNowInWeeks view" when {
       "answering 'Both the current tax year and previous year'" in {
         val mockAnswers = mock[UserAnswers]
         when(mockAnswers.claimAnyOtherExpense).thenReturn(None)
@@ -170,6 +170,30 @@ class NavigatorSpec extends SpecBase with MockitoSugar {
         when(mockAnswers.whichYearsAreYouClaimingFor).thenReturn(Some(3))
 
         navigator.nextPage(WhichYearsAreYouClaimingForId)(mockAnswers) mustBe
+          routes.InformCustomerClaimNowInWeeksController.onPageLoad()
+      }
+    }
+
+    "go to the SaCheckDisclaimerCurrentYear view" when {
+      "registered for SA, claiming for the current year only and navigating from InformCustomerClaimNowInWeeks" in {
+        val mockAnswers = mock[UserAnswers]
+        when(mockAnswers.claimAnyOtherExpense).thenReturn(None)
+        when(mockAnswers.registeredForSelfAssessment).thenReturn(Some(true))
+        when(mockAnswers.whichYearsAreYouClaimingFor).thenReturn(Some(1))
+
+        navigator.nextPage(InformCustomerClaimNowInWeeksId)(mockAnswers) mustBe
+          routes.SaCheckDisclaimerCurrentYearController.onPageLoad()
+      }
+    }
+
+    "go to the SaCheckDisclaimerAllYears view" when {
+      "registered for SA, claiming for current and previous years and navigating from InformCustomerClaimNowInWeeks" in {
+        val mockAnswers = mock[UserAnswers]
+        when(mockAnswers.claimAnyOtherExpense).thenReturn(None)
+        when(mockAnswers.registeredForSelfAssessment).thenReturn(Some(true))
+        when(mockAnswers.whichYearsAreYouClaimingFor).thenReturn(Some(3))
+
+        navigator.nextPage(InformCustomerClaimNowInWeeksId)(mockAnswers) mustBe
           routes.SaCheckDisclaimerAllYearsController.onPageLoad()
       }
     }

--- a/test/views/DisclaimerViewSpec.scala
+++ b/test/views/DisclaimerViewSpec.scala
@@ -33,7 +33,7 @@ class DisclaimerViewSpec extends NewViewBehaviours {
 
   def onwardRoute: Call = routes.IndexController.onPageLoad
 
-  def createView: HtmlFormat.Appendable = view.apply(claimant, claimingCurrent = true, claimingPrevious = true)(fakeRequest, messages)
+  def createView: HtmlFormat.Appendable = view.apply(claimant)(fakeRequest, messages)
 
   "DisclaimerView" must {
     behave like normalPage(createView, messageKeyPrefix)


### PR DESCRIPTION
# DL-9595 - Claim by weeks for SA-claimants

- added 'claim by week' disclaimer page for SA users.
- changed WFH disclaimer to always show guidance for all years
- changed UserAnswer lookup for `employerPaidBackWfhExpenses` to use a different key from `employerPaidBackExpenses`, as it caused an error navigating backwards from WFH to normal journey

## Checklist

*Stephen*
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
