### PR TITLE
DL-16767 - accessibility: add govuk-link class on print & post page

### DIFF
--- a/app/views/UseIformFreOnlyView.scala.html
+++ b/app/views/UseIformFreOnlyView.scala.html
@@ -65,7 +65,7 @@ if (claimingFor == List(HomeWorking) && appConfig.pegaServiceJourney){
         s"""
         ${pegaServiceJourneyInsertText} <br><br>
         ${messages("usePrintAndPostDetailed.para2_freOnly_iform")}
-        <a href="${appConfig.employeeExpensesClaimByPostUrl}" target="_blank">
+        <a class="govuk-link" href="${appConfig.employeeExpensesClaimByPostUrl}" target="_blank">
             ${messages("usePrintAndPostDetailed.para2_freOnly.link.label_iform")}
         </a>
         """


### PR DESCRIPTION
# DL-16767 - Accessibility Fix - Add govuk-link class to ensure correctly styled link text
Adds the accessible class 'govuk-link' to the 'claim by post' link on the use print and post form page