### PR TITLE
DL-16877 - adds inline error prefix (English & Welsh), apply to views

### DIFF
--- a/app/views/ClaimingForView.scala.html
+++ b/app/views/ClaimingForView.scala.html
@@ -60,7 +60,10 @@
             )),
             name = "value",
             items = ClaimingFor.options(appConfig.onlineJourneyShutterEnabled, appConfig.freOnlyJourneyEnabled),
-            errorMessage = form.errors.headOption.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+            errorMessage = form.errors.headOption.map(err => ErrorMessage(
+                content = Text(messages(err.message, err.args:_*)), 
+                visuallyHiddenText = Some(messages("error.inline.prefix"))
+            ))
         ))
 
         @submitButton()

--- a/app/views/playComponents/input_radio_or.scala.html
+++ b/app/views/playComponents/input_radio_or.scala.html
@@ -43,7 +43,7 @@
         }
         @field.errors.map { error =>
             <p class="govuk-error-message" id="error-message-@{field.id}-input">
-                <span class="govuk-visually-hidden">Error:</span> @messages(error.message, error.args: _*)
+                <span class="govuk-visually-hidden">@messages("error.inline.prefix"):</span> @messages(error.message, error.args: _*)
             </p>
         }
         <div class="govuk-radios" data-module="govuk-radios">

--- a/conf/messages
+++ b/conf/messages
@@ -18,6 +18,7 @@ error.non_numeric = Give a value using only numbers
 error.number = Please enter a valid number
 error.required = Please enter a value
 error.summary.title = There is a problem
+error.inline.prefix = Error
 
 session_expired.title = For your security, we deleted your answers
 session_expired.heading = For your security, we deleted your answers

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -18,6 +18,7 @@ error.non_numeric = Rhowch werth gan ddefnyddio rhifau yn unig
 error.number = Nodwch rif dilys
 error.required = Nodwch werth
 error.summary.title = Mae problem wedi codi
+error.inline.prefix = Gwall
 
 session_expired.title = Er eich diogelwch, gwnaethom ddileu’ch atebion
 session_expired.heading = Er eich diogelwch, gwnaethom ddileu’ch atebion


### PR DESCRIPTION
Adds the inline error prefix to the messages file, applies the prefix to the ClaimingFor view, and to the input_radio_or component.

This ensure the visually hidden 'Error:' prefix is correctly translated for both languages.

<img width="1662" height="1061" alt="Screenshot 2025-07-10 at 11 44 46" src="https://github.com/user-attachments/assets/4de0cafd-b223-46b9-99e1-62050c10798d" />
