### PR TITLE
DL-16879 updated disclaimer - warning component, Welsh translation, strip br tags

### DIFF
--- a/app/views/DisclaimerView.scala.html
+++ b/app/views/DisclaimerView.scala.html
@@ -21,6 +21,7 @@
         govukInsetText : GovukInsetText,
         heading: playComponents.heading,
         govukNotificationBanner: GovukNotificationBanner,
+        govukWarningText: GovukWarningText,
         submitButton: playComponents.submit_button,
         appConfig: FrontendAppConfig
 )
@@ -78,14 +79,10 @@
         <li>@messages("disclaimer.claim.before.l3")</li>
     </ul>
 
-    <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-            @messages("disclaimer.warning1")<br>
-            @messages("disclaimer.warning2")<br>
-        </strong>
-    </div>
+    @govukWarningText(WarningText(
+        iconFallbackText = Some(messages("site.warning")),
+        content = Text(messages("disclaimer.warning"))
+    ))
 
     <p class="govuk-body">@messages("disclaimer.accept")</p>
 

--- a/conf/messages
+++ b/conf/messages
@@ -36,6 +36,7 @@ site.save_and_continue = Continue
 site.service_name = Check if you can claim work related expenses
 site.textarea.char_limit = (Limit is {0} characters)
 site.gov.uk = GOV.UK
+site.warning = Warning
 
 claimant.title = Who are you claiming expenses for?
 claimant.heading = Who are you claiming expenses for?
@@ -344,8 +345,7 @@ disclaimer.claim.before.p1 = You can claim if all the following rules apply:
 disclaimer.claim.before.l1 = your employer has not already paid your expenses
 disclaimer.claim.before.l2 = government guidelines have required you to work from home or self-isolate
 disclaimer.claim.before.l3 = you have additional household costs as a result of working from home
-disclaimer.warning1 = Guidance has changed from 6 April 2022.
-disclaimer.warning2 = You must ensure you meet the rules for claiming, as you may be prosecuted if you deliberately give incorrect or misleading information.
+disclaimer.warning = Guidance has changed from 6 April 2022. You must ensure you meet the rules for claiming, as you may be prosecuted if you deliberately give incorrect or misleading information.
 disclaimer.accept = By clicking accept and continue, you are accepting that you meet the rules for the years you are claiming for.
 disclaimer.button.continue = Accept and continue
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -36,6 +36,7 @@ site.save_and_continue = Yn eich blaen
 site.service_name = Gwiriwch a allwch hawlio treuliau sy’n ymwneud â gwaith
 site.textarea.char_limit = (Y terfyn yw {0} o gymeriadau)
 site.gov.uk = GOV.UK
+site.warning = Rhybudd
 
 claimant.title = Ar gyfer pwy yr ydych yn hawlio treuliau?
 claimant.heading = Ar gyfer pwy yr ydych yn hawlio treuliau?
@@ -343,8 +344,7 @@ disclaimer.claim.before.p1 = Gallwch wneud hawliad os yw pob un o’r rheolau ca
 disclaimer.claim.before.l1 = nid yw’ch cyflogwr wedi talu’ch treuliau’n barod
 disclaimer.claim.before.l2 = mae canllawiau’r llywodraeth wedi gofyn eich bod yn gweithio gartref neu’n hunanynysu
 disclaimer.claim.before.l3 = mae costau’ch aelwyd wedi cynyddu o ganlyniad i weithio gartref
-disclaimer.warning1 = Mae’r arweiniad wedi newid ers 6 Ebrill 2022.
-disclaimer.warning2 = Mae’n rhaid i chi sicrhau eich bod yn bodloni’r rheolau ar gyfer hawlio, gan y gallech gael eich erlyn os byddwch yn rhoi gwybodaeth anwir neu gamarweiniol yn fwriadol.
+disclaimer.warning = Mae’r arweiniad wedi newid ers 6 Ebrill 2022. Mae’n rhaid i chi sicrhau eich bod yn bodloni’r rheolau ar gyfer hawlio, gan y gallech gael eich erlyn os byddwch yn rhoi gwybodaeth anwir neu gamarweiniol yn fwriadol.
 disclaimer.accept = Drwy glicio ar ‘Derbyn ac yn eich blaen’, rydych yn derbyn eich bod yn bodloni’r rheolau ar gyfer y blynyddoedd rydych yn hawlio amdanynt.
 disclaimer.button.continue = Derbyn ac yn eich blaen
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object AppDependencies {
-  val bootstrapVersion = "9.13.0"
+  val bootstrapVersion = "9.14.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ resolvers += "Typesafe Releases".at("https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.4")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.3.1")


### PR DESCRIPTION
Following guidance from the accessibility assessment, we have removed <br /> tags from the Warning component as this was causing problems for screen reader users.

Additionally, the GovUK warning component has replaced a hardcoded adaption of the component, and the Warning text has been correctly hidden from non-screen reader users.
The Warning text has been moved to the messages file, with a Welsh translation provided.

**Before**
<img width="955" height="871" alt="Screenshot 2025-07-11 at 15 00 47" src="https://github.com/user-attachments/assets/330a24a1-66d1-4fc5-8bae-1ef940e7fcfc" />

**After**
<img width="743" height="881" alt="Screenshot 2025-07-11 at 16 41 04" src="https://github.com/user-attachments/assets/f76f2356-e277-48cf-8549-b9b0e20fbc01" />

<img width="295" height="312" alt="Screenshot 2025-07-11 at 16 42 12" src="https://github.com/user-attachments/assets/1ec76aa5-14d4-423f-8012-b87262574ada" />

<img width="305" height="316" alt="Screenshot 2025-07-11 at 16 42 25" src="https://github.com/user-attachments/assets/de3e5168-1ddb-4124-847f-3f2bd9d7b30f" />


