### PR TITLE
DL-19412 - add hint & inline error to fieldset aria-describedby

### DIFF
--- a/app/views/EmployerPaidBackAnyExpensesView.scala.html
+++ b/app/views/EmployerPaidBackAnyExpensesView.scala.html
@@ -20,7 +20,6 @@
     layout: Layout,
     formHelper: uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF,
     errorSummary: playComponents.error_summary,
-    heading: playComponents.heading,
     inputRadioOr: playComponents.input_radio_or,
     submitButton: playComponents.submit_button
 )
@@ -35,16 +34,13 @@
 
         @errorSummary(form.errors, Some("employerPaid.noExpenses"))
 
-        @heading(messages(s"employerPaidBackAnyExpenses.heading"))
-
-        <p class="govuk-body">@messages("employerPaidBackAnyExpenses.info")</p>
-
         @inputRadioOr(
             field = form("value"),
             legend = messages("employerPaidBackAnyExpenses.heading"),
-            legendClass = Some("govuk-visually-hidden"),
+            legendClass = Some("govuk-fieldset__heading"),
+            hint = Some(messages("employerPaidBackAnyExpenses.info")),
             inputs = EmployerPaid.options.toSeq,
-            isPageHeading = false
+            isPageHeading = true
         )
 
         @submitButton()

--- a/app/views/playComponents/input_radio_or.scala.html
+++ b/app/views/playComponents/input_radio_or.scala.html
@@ -29,41 +29,53 @@
     isPageHeading: Boolean = true
 )(implicit messages: Messages)
 
-<div class="govuk-form-group @if(field.hasErrors){govuk-form-group--error}">
-    <fieldset class="govuk-fieldset" id="@{field.id}">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            @if(isPageHeading) {
-                <h1 class="@{legendClass.get}">@legend</h1>
-            } else {
-                <span class="@{legendClass.get}">@legend</span>
-            }
-        </legend>
-        @if(hint.nonEmpty){
-            <p class="govuk-hint">@{hint.get}</p>
-        }
-        @field.errors.map { error =>
-            <p class="govuk-error-message" id="error-message-@{field.id}-input">
-                <span class="govuk-visually-hidden">@messages("error.inline.prefix"):</span> @messages(error.message, error.args: _*)
-            </p>
-        }
-        <div class="govuk-radios" data-module="govuk-radios">
-            @for(input <- inputs) {
-                @if(input != inputs.last) {
-                    <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="@{input.id}" name="@{field.id}" type="radio" value="@{input.value}">
-                        <label class="govuk-label govuk-radios__label" for="@{input.id}">
-                            @input.message.html
-                        </label>
-                    </div>
+@defining({
+  val hintId      = s"${field.id}-hint"
+  val errorId     = s"${field.id}-error"
+  val describedBy = Seq(
+    hint.map(_ => hintId),
+    if (field.hasErrors) Some(errorId) else None
+  ).flatten.mkString(" ")
+  (hintId, errorId, describedBy)
+}) { case (hintId, errorId, describedBy) =>
+
+    <div class="govuk-form-group @if(field.hasErrors){govuk-form-group--error}">
+        <fieldset class="govuk-fieldset" id="@{field.id}" @if(describedBy.nonEmpty){aria-describedby="@describedBy"}>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+                @if(isPageHeading) {
+                    <h1 class="@{legendClass.get}">@legend</h1>
+                } else {
+                    <span class="@{legendClass.get}">@legend</span>
                 }
+            </legend>
+            @if(hint.nonEmpty){
+                <p class="govuk-hint" id="@hintId">@{hint.get}</p>
             }
-            <div class="govuk-radios__divider">@messages("site.or")</div>
-            <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="@{inputs.last.id}" name="@{field.id}" type="radio" value="@{inputs.last.value}">
-                <label class="govuk-label govuk-radios__label" for="@{inputs.last.id}">
-                    @inputs.last.message.html
-                </label>
+            @field.errors.map { error =>
+                <p class="govuk-error-message" id="@errorId">
+                    <span class="govuk-visually-hidden">@messages("error.inline.prefix"):</span> @messages(error.message, error.args: _*)
+                </p>
+            }
+            <div class="govuk-radios" data-module="govuk-radios">
+                @for(input <- inputs) {
+                    @if(input != inputs.last) {
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="@{input.id}" name="@{field.id}" type="radio" value="@{input.value}">
+                            <label class="govuk-label govuk-radios__label" for="@{input.id}">
+                                @input.message.html
+                            </label>
+                        </div>
+                    }
+                }
+                <div class="govuk-radios__divider">@messages("site.or")</div>
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="@{inputs.last.id}" name="@{field.id}" type="radio" value="@{inputs.last.value}">
+                    <label class="govuk-label govuk-radios__label" for="@{inputs.last.id}">
+                        @inputs.last.message.html
+                    </label>
+                </div>
             </div>
-        </div>
-    </fieldset>
-</div>
+        </fieldset>
+    </div>
+    
+}


### PR DESCRIPTION
Adds the aria-describedby attribute to the inputRadioOr component to link the error and hint to the fieldset.
Also removes the repeated H1, and makes the **Has your employer paid any of your expenses in this claim?** page follow the question page pattern. The legend is the H1, and the copy is hint text.

This was confirmed as appropriate by Kate James

<img width="468" height="454" alt="Screenshot 2026-06-05 at 15 30 56" src="https://github.com/user-attachments/assets/e2ae5409-6cc0-4cef-8ec9-672e3676b9f8" />

<img width="479" height="365" alt="Screenshot 2026-06-05 at 15 30 34" src="https://github.com/user-attachments/assets/39081d24-32a6-404f-ac45-22d172476b52" />
